### PR TITLE
Modules are free now on Odoo Store

### DIFF
--- a/cron_seconds/__manifest__.py
+++ b/cron_seconds/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Tools",
 }

--- a/simple_website_sale_clear_cart/__manifest__.py
+++ b/simple_website_sale_clear_cart/__manifest__.py
@@ -15,7 +15,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Website",
 }

--- a/website_debug_restrict/__manifest__.py
+++ b/website_debug_restrict/__manifest__.py
@@ -14,7 +14,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Website",
     "assets": {

--- a/website_enhanced_google_tag_manager/__manifest__.py
+++ b/website_enhanced_google_tag_manager/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Website",
 }

--- a/website_geoip_language/__manifest__.py
+++ b/website_geoip_language/__manifest__.py
@@ -19,7 +19,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Website",
 }

--- a/website_improved_sale_schema/__manifest__.py
+++ b/website_improved_sale_schema/__manifest__.py
@@ -16,7 +16,7 @@
     "installable": True,
     # Odoo Apps Store Specific #
     "images": ["static/description/banner.png"],
-    "price": 10.00,
+    "price": 0.00,
     "currency": "EUR",
     "category": "Website",
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Multiple modules are now available for free, reducing barriers to access and encouraging wider adoption.
  
- **Impact**
  - Users can now utilize the following modules without any cost:
    - cron_seconds
    - simple_website_sale_clear_cart
    - website_debug_restrict
    - website_enhanced_google_tag_manager
    - website_geoip_language
    - website_improved_sale_schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->